### PR TITLE
Avoid errors trying to find scope in census authorization handler

### DIFF
--- a/decidim-census/app/services/census_authorization_handler.rb
+++ b/decidim-census/app/services/census_authorization_handler.rb
@@ -50,7 +50,7 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def scope
-    Decidim::Scope.find(scope_id)
+    Decidim::Scope.find_by(id: scope_id)
   end
 
   def census_for_user


### PR DESCRIPTION
This PR avoids exceptions trying to find a scope without an id. This error occurs when admins try to manage new participants in impersonations