### PR TITLE
Add a patch to fix ActiveSupport::Cache::FileStore file_path_key issue

### DIFF
--- a/config/initializers/activesupport_overrides.rb
+++ b/config/initializers/activesupport_overrides.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "extensions/cache_file_store_override"
+
+Rails.application.config.to_prepare do
+  if ActiveSupport.version < "7.0"
+    ActiveSupport::Cache::FileStore.include(CacheFileStoreOverride)
+  else
+    ::Kernel.warn("Remove the ActiveSupport::Cache::FileStore override because the current ActiveSupport version (#{ActiveSupport.version.version}) includes this fix")
+  end
+end

--- a/lib/extensions/cache_file_store_override.rb
+++ b/lib/extensions/cache_file_store_override.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module CacheFileStoreOverride
+  extend ActiveSupport::Concern
+
+  # This is a fix included in Rails since version 7.0. This is required to
+  # avoid errors trying to clear cache using Rails.cache.delete_matched when
+  # cache uses ActiveSupport::Cache::FileStore and long cache keys are used
+  #
+  # See: https://github.com/rails/rails/pull/49694
+  # Related: https://github.com/rails/rails/issues/49690
+  included do
+    # Translate a file path into a key.
+    def file_path_key(path)
+      fname = path[cache_path.to_s.size..-1].split(File::SEPARATOR, 4).last.delete(File::SEPARATOR)
+      URI.decode_www_form_component(fname, Encoding::UTF_8)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a patch applied in Rails since 7.0 version to avoid errors trying to clear cache using `delete_matched` method

See https://github.com/rails/rails/pull/49694