### PR TITLE
Add task to migrate spaces images to hero content blocks

### DIFF
--- a/lib/tasks/contents_migrations.rake
+++ b/lib/tasks/contents_migrations.rake
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+namespace :populate_tasks do
+  namespace :contents_migrations do
+    desc "migrate space images to hero content blocks"
+    task migrate_spaces_hero_blocks: [:environment] do
+      migrate_spaces(Decidim::ParticipatoryProcess.all, "participatory_process_homepage", "banner_image")
+      migrate_spaces(Decidim::Assembly.all, "assembly_homepage", "banner_image")
+      migrate_spaces(Decidim::ParticipatoryProcessGroup.all, "participatory_process_group_homepage", "hero_image")
+    end
+  end
+end
+
+def migrate_spaces(spaces_list, scope_name, space_attachment_attribute)
+  spaces_list.each do |space|
+    hero_content_block = Decidim::ContentBlock.find_by(scope_name:, scoped_resource_id: space.id, manifest_name: "hero")
+    hero_attachment = hero_content_block.attachments.find_by_name("background_image")
+    next if hero_attachment.blank?
+    next if hero_attachment.file.attached?
+    next unless space.send(space_attachment_attribute).attached?
+
+    space.send(space_attachment_attribute).blob.open { |_| }
+
+    hero_attachment.file.attach(space.send(space_attachment_attribute).blob)
+  rescue ActiveStorage::FileNotFoundError
+    puts "Skipped due to errors accessing blob content..."
+  end
+end

--- a/lib/tasks/contents_migrations.rake
+++ b/lib/tasks/contents_migrations.rake
@@ -4,25 +4,45 @@ namespace :populate_tasks do
   namespace :contents_migrations do
     desc "migrate space images to hero content blocks"
     task migrate_spaces_hero_blocks: [:environment] do
-      migrate_spaces(Decidim::ParticipatoryProcess.all, "participatory_process_homepage", "banner_image")
-      migrate_spaces(Decidim::Assembly.all, "assembly_homepage", "banner_image")
+      migrate_spaces(Decidim::ParticipatoryProcess.all, "participatory_process_homepage", %w(banner_image hero_image))
+      migrate_spaces(Decidim::Assembly.all, "assembly_homepage", %w(banner_image hero_image))
       migrate_spaces(Decidim::ParticipatoryProcessGroup.all, "participatory_process_group_homepage", "hero_image")
     end
   end
 end
 
-def migrate_spaces(spaces_list, scope_name, space_attachment_attribute)
+def migrate_spaces(spaces_list, scope_name, space_attachment_attributes)
+  space_attachment_attributes = [space_attachment_attributes] unless space_attachment_attributes.is_a?(Array)
   spaces_list.each do |space|
     hero_content_block = Decidim::ContentBlock.find_by(scope_name:, scoped_resource_id: space.id, manifest_name: "hero")
-    hero_attachment = hero_content_block.attachments.find_by_name("background_image")
+    hero_attachment = hero_content_block.attachments.find_by(name: "background_image")
     next if hero_attachment.blank?
     next if hero_attachment.file.attached?
-    next unless space.send(space_attachment_attribute).attached?
 
-    space.send(space_attachment_attribute).blob.open { |_| }
+    blob = get_blob(space, space_attachment_attributes)
 
-    hero_attachment.file.attach(space.send(space_attachment_attribute).blob)
+    if blob.blank?
+      puts "No image found for space #{space.class.name} #{space.id}"
+    else
+      puts "Image migrated in space #{space.class.name} #{space.id}"
+      hero_attachment.file.attach(blob)
+    end
   rescue ActiveStorage::FileNotFoundError
     puts "Skipped due to errors accessing blob content..."
   end
+end
+
+def get_blob(space, attachment_attributes)
+  blob = nil
+  attachment_attributes.each do |attachment_attribute|
+    next if blob.present?
+    next unless space.send(attachment_attribute).is_a?(ActiveStorage::Attached)
+    next unless space.send(attachment_attribute).attached?
+
+    space.send(attachment_attribute).blob.open { |_| }
+
+    blob = space.send(attachment_attribute).blob
+  end
+
+  blob
 end

--- a/lib/tasks/contents_migrations.rake
+++ b/lib/tasks/contents_migrations.rake
@@ -15,6 +15,8 @@ def migrate_spaces(spaces_list, scope_name, space_attachment_attributes)
   space_attachment_attributes = [space_attachment_attributes] unless space_attachment_attributes.is_a?(Array)
   spaces_list.each do |space|
     hero_content_block = Decidim::ContentBlock.find_by(scope_name:, scoped_resource_id: space.id, manifest_name: "hero")
+    next if hero_content_block.blank?
+
     hero_attachment = hero_content_block.attachments.find_by(name: "background_image")
     next if hero_attachment.blank?
     next if hero_attachment.file.attached?


### PR DESCRIPTION
This PR adds a task to move banner_image or hero_image if banner image is not available to the attachment of the hero content block of the space if present.