### PR TITLE
Change locales configuration and define fallback in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,9 @@ module DecidimDiba
     config.active_record.default_timezone = :local
     config.active_record.time_zone_aware_attributes = false
 
+    config.i18n.available_locales = Decidim.available_locales
+    config.i18n.default_locale = Decidim.default_locale
+
     # Make decorators available
     config.to_prepare do
       # activate Decidim LayoutHelper for the overriden views

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
   config.action_mailer.perform_caching = false
 
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [:en]
 
   config.active_support.deprecation = :notify
 

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -517,9 +517,6 @@ if Decidim.module_installed? :elections
   end
 end
 
-Rails.application.config.i18n.available_locales = Decidim.available_locales
-Rails.application.config.i18n.default_locale = Decidim.default_locale
-
 Decidim::Ldap.configure do |config|
   config.ldap_username = Rails.application.secrets.ldap[:username]
   config.ldap_password = Rails.application.secrets.ldap[:password]


### PR DESCRIPTION
This PR fixes the locales configuration to use the `:en` locale as fallback in production